### PR TITLE
refactor: remove unused OnInit hook

### DIFF
--- a/src/app/pages/auth/sign-up/sign-up.component.ts
+++ b/src/app/pages/auth/sign-up/sign-up.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-sign-up',
@@ -6,10 +6,4 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./sign-up.component.scss'],
   standalone: true,
 })
-export class SignUpComponent  implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {}
-
-}
+export class SignUpComponent {}


### PR DESCRIPTION
## Summary
- clean up SignUpComponent by removing unused OnInit lifecycle hook

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: Async pipe negation in layout.component.html)*
- `npx ng lint --lint-file-patterns src/app/pages/auth/sign-up/sign-up.component.ts`


------
https://chatgpt.com/codex/tasks/task_e_68996c2a64b4832dad4682aa0f8f5111