### PR TITLE
feat(api-keys): add ApiKey interface and toast notifications

### DIFF
--- a/src/app/pages/api-keys/api-keys.component.spec.ts
+++ b/src/app/pages/api-keys/api-keys.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
+import { AlertController } from '@ionic/angular';
 import { ApiKeysComponent } from './api-keys.component';
+import { ToastService } from 'src/app/core/services/toast.service';
 
 describe('ApiKeysComponent', () => {
   let component: ApiKeysComponent;
@@ -9,6 +10,10 @@ describe('ApiKeysComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ApiKeysComponent],
+      providers: [
+        { provide: AlertController, useValue: { create: () => Promise.resolve({ present: () => Promise.resolve() }) } },
+        { provide: ToastService, useValue: { present: () => Promise.resolve() } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApiKeysComponent);

--- a/src/app/pages/api-keys/api-keys.component.ts
+++ b/src/app/pages/api-keys/api-keys.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   IonHeader,
@@ -16,8 +16,17 @@ import {
   IonCardContent,
   IonButtons,
 } from '@ionic/angular/standalone';
+import { AlertController } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { add, trash, eye } from 'ionicons/icons';
+import { ToastService } from 'src/app/core/services/toast.service';
+
+export interface ApiKey {
+  name: string;
+  prefix: string;
+  createdAt: Date;
+  lastUsed: Date;
+}
 
 @Component({
   selector: 'app-api-keys',
@@ -43,23 +52,55 @@ import { add, trash, eye } from 'ionicons/icons';
   ],
 })
 export class ApiKeysComponent {
-  public apiKeys = [
+  public apiKeys: ApiKey[] = [
     { name: 'My First Key', prefix: 'sk_123...', createdAt: new Date(), lastUsed: new Date() },
     { name: 'Marketing Campaign Key', prefix: 'sk_abc...', createdAt: new Date(), lastUsed: new Date() },
     { name: 'Staging Environment Key', prefix: 'sk_xyz...', createdAt: new Date(), lastUsed: new Date() },
   ];
 
+  private alertController = inject(AlertController);
+  private toastService = inject(ToastService);
+
   constructor() {
     addIcons({ add, trash, eye });
   }
 
-  createKey() {
-    // Logic to open a dialog to create a new key
-    console.log('Create new key');
+  async createKey() {
+    const alert = await this.alertController.create({
+      header: 'Create API Key',
+      inputs: [
+        {
+          name: 'name',
+          type: 'text',
+          placeholder: 'Key name',
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Create',
+          handler: (data) => {
+            const newKey: ApiKey = {
+              name: data.name || 'New API Key',
+              prefix: `sk_${Math.random().toString(36).substring(2, 8)}...`,
+              createdAt: new Date(),
+              lastUsed: new Date(),
+            };
+            this.apiKeys.push(newKey);
+            this.toastService.present({ message: 'API key created' });
+          },
+        },
+      ],
+    });
+
+    await alert.present();
   }
 
-  revokeKey(key: any) {
-    // Logic to revoke the key
-    console.log('Revoke key', key);
+  revokeKey(key: ApiKey) {
+    this.apiKeys = this.apiKeys.filter(k => k !== key);
+    this.toastService.present({ message: 'API key revoked' });
   }
 }


### PR DESCRIPTION
## Summary
- add ApiKey interface and enforce typed revokeKey
- replace console logs with Alert-based key creation and toast notifications
- mock AlertController and ToastService in ApiKeysComponent tests

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test -- --watch=false --browsers=ChromeHeadless` *(fails: "Command '/usr/bin/chromium-browser' requires the chromium snap to be installed.")*
- `npm run lint` *(fails: Lint errors found in the listed files)*

------
https://chatgpt.com/codex/tasks/task_e_68996c2a81dc832d814c4d010570f883