### PR TITLE
feat: show toast on sign in error

### DIFF
--- a/src/app/pages/auth/sign-in/sign-in.component.ts
+++ b/src/app/pages/auth/sign-in/sign-in.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { IonContent, IonCard, IonCardHeader, IonCardTitle, IonCardContent, IonList, IonItem, IonInput, IonButton, IonSpinner } from '@ionic/angular/standalone';
 import { AuthService } from 'src/app/core/services/auth.service';
+import { ToastService } from 'src/app/core/services/toast.service';
 
 @Component({
   selector: 'app-sign-in',
@@ -29,6 +30,7 @@ import { AuthService } from 'src/app/core/services/auth.service';
 export class SignInPage implements OnInit {
   private fb = inject(FormBuilder);
   private authService = inject(AuthService);
+  private toastService = inject(ToastService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private returnUrl!: string;
@@ -56,7 +58,7 @@ export class SignInPage implements OnInit {
       },
       error: (err) => {
         this.loading = false;
-        // The error interceptor will handle the toast
+        this.toastService.presentError('Sign in failed. Please check your credentials and try again.');
       },
     });
   }


### PR DESCRIPTION
## Summary
- show toast error message when sign in fails

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Lifecycle methods should not be empty; Async pipe results should not be negated)*

------
https://chatgpt.com/codex/tasks/task_e_68996c2c1ad0832d99a5ea4d4162c15f