### PR TITLE
Return copy of available models

### DIFF
--- a/src/app/core/services/model-selector.service.ts
+++ b/src/app/core/services/model-selector.service.ts
@@ -8,7 +8,7 @@ import { STORAGE_KEYS } from '../constants';
 })
 export class ModelSelectorService {
   // In a real app, this would be fetched from an API
-  private availableModels: Model[] = [
+  private readonly availableModels: Model[] = [
     { id: '1', name: 'FraudNet', version: '1.0.0', alias: 'latest' },
     { id: '2', name: 'FraudNet', version: '0.9.0' },
     { id: '3', name: 'RiskGuard', version: '2.1.0', alias: 'beta' },
@@ -41,7 +41,7 @@ export class ModelSelectorService {
   }
 
   getAvailableModels(): Model[] {
-    return this.availableModels;
+    return [...this.availableModels];
   }
 
   setSelectedModel(model: Model) {


### PR DESCRIPTION
## Summary
- ensure `getAvailableModels` returns a shallow copy of the internal model list
- mark `availableModels` as readonly to prevent mutation

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68996c2a8468832db04fc20a0e63f2c1