### PR TITLE
fix: avoid negated async pipe in layout component

### DIFF
--- a/src/app/pages/layout/layout.component.html
+++ b/src/app/pages/layout/layout.component.html
@@ -12,7 +12,7 @@
         <ion-badge *ngIf="apiKeyService.isApiKeyActive$ | async" color="success" style="margin-left: 8px;">API Key Active</ion-badge>
       </ion-button>
       <ion-button routerLink="/keys" *ngIf="authService.user$ | async">API Keys</ion-button>
-      <ion-button *ngIf="!(authService.user$ | async)" routerLink="/login" color="light" shape="round">Login</ion-button>
+      <ion-button *ngIf="(authService.user$ | async) === null" routerLink="/login" color="light" shape="round">Login</ion-button>
       <ion-button *ngIf="authService.user$ | async" (click)="logout()" color="light" shape="round">Logout</ion-button>
     </ion-buttons>
   </ion-toolbar>


### PR DESCRIPTION
## Summary
- replace negated async pipe usage in layout login button with explicit null check to satisfy lint rules

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*


------
https://chatgpt.com/codex/tasks/task_e_6899748890fc832db2d83f8dbcef1fcd