### PR TITLE
Fix unit tests by using HttpClientTesting providers and router mocks

### DIFF
--- a/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './auth.interceptor';
 import { ApiKeyService } from '../services/api-key.service';
@@ -16,9 +16,9 @@ describe('authInterceptor', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
         provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
         { provide: ApiKeyService, useValue: apiKeyServiceMock },
       ],
     });

--- a/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/src/app/core/interceptors/error.interceptor.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { HttpClient, HttpErrorResponse, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { errorInterceptor } from './error.interceptor';
@@ -27,9 +27,9 @@ describe('ErrorInterceptor', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
         provideHttpClient(withInterceptors([errorInterceptor])),
+        provideHttpClientTesting(),
         { provide: AuthService, useValue: authServiceMock },
         { provide: ToastService, useValue: toastServiceMock },
         { provide: Router, useValue: routerMock },

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -15,10 +15,10 @@ describe('AuthService', () => {
       imports: [HttpClientTestingModule],
       providers: [AuthService],
     });
-    service = TestBed.inject(AuthService);
     httpMock = TestBed.inject(HttpTestingController);
     localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
     environment.useMock = false; // Ensure we are testing the real service logic
+    service = TestBed.inject(AuthService);
   });
 
   afterEach(() => {

--- a/src/app/pages/auth/sign-in/sign-in.component.spec.ts
+++ b/src/app/pages/auth/sign-in/sign-in.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { SignInPage } from './sign-in.component';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { ToastService } from 'src/app/core/services/toast.service';
 
 describe('SignInPage', () => {
   let component: SignInPage;
@@ -8,7 +11,11 @@ describe('SignInPage', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SignInPage],
+      imports: [SignInPage, RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: ToastService, useValue: {} },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SignInPage);

--- a/src/app/pages/landing/landing.component.spec.ts
+++ b/src/app/pages/landing/landing.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { LandingPage } from './landing.component';
 
@@ -8,7 +9,7 @@ describe('LandingPage', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [LandingPage],
+      imports: [LandingPage, RouterTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LandingPage);

--- a/src/app/pages/layout/layout.component.spec.ts
+++ b/src/app/pages/layout/layout.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { LayoutPage } from './layout.component';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { ApiKeyService } from 'src/app/core/services/api-key.service';
 
 describe('LayoutPage', () => {
   let component: LayoutPage;
@@ -8,7 +11,11 @@ describe('LayoutPage', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [LayoutPage],
+      imports: [LayoutPage, RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: { signOut: () => {} } },
+        { provide: ApiKeyService, useValue: {} },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LayoutPage);


### PR DESCRIPTION
## Summary
- Use provideHttpClientTesting with interceptor specs to avoid real HTTP requests
- Mock router and service dependencies for standalone component tests
- Reset AuthService test setup to clear tokens before injection

## Testing
- `CHROME_BIN=/tmp/chrome-headless.sh npm test -- --watch=false --browsers=ChromeHeadless`


------
https://chatgpt.com/codex/tasks/task_e_689978be7e8c832d99d1818c091c7979