### PR TITLE
feat(theme): add light and dark color variables

### DIFF
--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -1,2 +1,19 @@
 // For information on how to create your own theme, please see:
 // http://ionicframework.com/docs/theming/
+
+:root {
+  /* Light mode colors from Ionic color guidelines for accessible contrast */
+  --color-primary: #3880ff; /* Primary brand color */
+  --color-secondary: #0cd1e8; /* Complementary accent color */
+  --color-background: #ffffff;
+  --color-text: #000000;
+}
+
+.dark {
+  /* Dark mode colors ensuring sufficient contrast */
+  --color-primary: #4c8dff;
+  --color-secondary: #50c8ff;
+  --color-background: #000000;
+  --color-text: #ffffff;
+}
+


### PR DESCRIPTION
## Summary
- add CSS variables for primary, secondary, background, and text colors
- provide light (:root) and dark (.dark) mode definitions per Ionic contrast guidelines

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899c9075174832db884802b5443d630