### PR TITLE
feat: add theme service for dark mode

### DIFF
--- a/src/app/core/constants.ts
+++ b/src/app/core/constants.ts
@@ -2,4 +2,5 @@ export const STORAGE_KEYS = {
   AUTH_TOKEN: 'fraudai.auth.v1',
   PLAYGROUND_KEY: 'fraudai.playground.key.v1',
   MODEL_SELECTOR: 'fraudai.model.selector.v1',
+  THEME: 'fraudai.theme.v1',
 };

--- a/src/app/core/services/theme.service.spec.ts
+++ b/src/app/core/services/theme.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { ThemeService } from './theme.service';
+import { DOCUMENT } from '@angular/common';
+import { STORAGE_KEYS } from '../constants';
+
+describe('ThemeService', () => {
+  let service: ThemeService;
+  let documentRef: Document;
+
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEYS.THEME);
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ThemeService);
+    documentRef = TestBed.inject(DOCUMENT);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should toggle dark class and persist choice', () => {
+    service.setDark(true);
+    expect(documentRef.body.classList.contains('dark')).toBeTrue();
+    expect(localStorage.getItem(STORAGE_KEYS.THEME)).toBe('dark');
+
+    service.toggle();
+    expect(documentRef.body.classList.contains('dark')).toBeFalse();
+    expect(localStorage.getItem(STORAGE_KEYS.THEME)).toBe('light');
+  });
+});

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { STORAGE_KEYS } from '../constants';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private document = inject(DOCUMENT);
+  private dark = false;
+
+  constructor() {
+    const stored = localStorage.getItem(STORAGE_KEYS.THEME);
+    this.dark = stored === 'dark';
+    this.apply();
+  }
+
+  isDark(): boolean {
+    return this.dark;
+  }
+
+  setDark(isDark: boolean): void {
+    this.dark = isDark;
+    this.apply();
+    localStorage.setItem(STORAGE_KEYS.THEME, isDark ? 'dark' : 'light');
+  }
+
+  toggle(): void {
+    this.setDark(!this.dark);
+  }
+
+  private apply(): void {
+    this.document.body.classList.toggle('dark', this.dark);
+  }
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -33,5 +33,4 @@
  */
 
 /* @import "@ionic/angular/css/palettes/dark.always.css"; */
-/* @import "@ionic/angular/css/palettes/dark.class.css"; */
-@import '@ionic/angular/css/palettes/dark.system.css';
+@import "@ionic/angular/css/palettes/dark.class.css";


### PR DESCRIPTION
## Summary
- add ThemeService to persist and toggle dark mode via body class
- switch global stylesheet to class-based dark mode import
- expose dark mode API for components

## Testing
- `npm run lint`
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*


------
https://chatgpt.com/codex/tasks/task_e_6899c90754f0832da8e20a7ca4a9f8ec