### PR TITLE
feat: add hero section to landing page

### DIFF
--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -1,19 +1,20 @@
 <ion-content class="ion-padding">
-  <div class="ion-text-center" style="height: 100%; display: flex; flex-direction: column; justify-content: center;">
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>
-          <h1>Welcome to Fraud AI</h1>
-        </ion-card-title>
-        <ion-card-subtitle>The most advanced fraud detection platform.</ion-card-subtitle>
-      </ion-card-header>
-      <ion-card-content>
+  <ion-grid class="hero">
+    <ion-row class="ion-align-items-center ion-justify-content-center">
+      <ion-col size="12" size-md="6" class="hero-text">
+        <h1>Welcome to Fraud AI</h1>
         <p>
           Leverage the power of artificial intelligence to protect your business from fraudulent activities.
           Our platform provides real-time analysis and insights to help you make informed decisions.
         </p>
-        <ion-button routerLink="/playground" size="large" class="ion-margin-top">Get Started</ion-button>
-      </ion-card-content>
-    </ion-card>
-  </div>
+        <div class="cta-buttons">
+          <ion-button routerLink="/playground" size="large" color="primary">Get Started</ion-button>
+          <ion-button routerLink="/docs" size="large" color="secondary" fill="outline">Learn More</ion-button>
+        </div>
+      </ion-col>
+      <ion-col size="12" size-md="6" class="hero-image">
+        <ion-img src="assets/shapes.svg" alt="Fraud AI Illustration"></ion-img>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
 </ion-content>

--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -1,0 +1,69 @@
+ion-content, .hero {
+  height: 100%;
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.hero-text {
+  text-align: center;
+}
+
+.hero-text h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--ion-color-primary);
+}
+
+.hero-text p {
+  font-size: 1.125rem;
+  margin-top: 1rem;
+}
+
+.cta-buttons {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-image {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.hero-image ion-img {
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .hero {
+    padding: 4rem 2rem;
+  }
+
+  .hero-text {
+    text-align: left;
+  }
+
+  .hero-text h1 {
+    font-size: 4rem;
+  }
+
+  .hero-text p {
+    font-size: 1.25rem;
+  }
+
+  .cta-buttons {
+    flex-direction: row;
+    justify-content: flex-start;
+  }
+
+  .hero-image {
+    margin-top: 0;
+  }
+}

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -3,11 +3,10 @@ import { RouterLink } from '@angular/router';
 import {
   IonContent,
   IonButton,
-  IonCard,
-  IonCardHeader,
-  IonCardTitle,
-  IonCardSubtitle,
-  IonCardContent,
+  IonGrid,
+  IonRow,
+  IonCol,
+  IonImg,
 } from '@ionic/angular/standalone';
 
 @Component({
@@ -19,11 +18,10 @@ import {
     RouterLink,
     IonContent,
     IonButton,
-    IonCard,
-    IonCardHeader,
-    IonCardTitle,
-    IonCardSubtitle,
-    IonCardContent,
+    IonGrid,
+    IonRow,
+    IonCol,
+    IonImg,
   ],
 })
 export class LandingPage {}


### PR DESCRIPTION
## Summary
- replace card-based landing with full-width hero grid and responsive CTAs
- style hero with SCSS, flex utilities, and responsive typography
- update component imports for grid, column, row, and image components

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless failed to start; snap install required)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899c9075c34832da2adb2dc362f9c71