### PR TITLE
Refactor docs page with grid layout and theme-aware styles

### DIFF
--- a/src/app/pages/docs/docs.component.html
+++ b/src/app/pages/docs/docs.component.html
@@ -1,36 +1,48 @@
 <ion-content class="ion-padding">
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>
+  <ion-grid>
+    <ion-row>
+      <ion-col size="12">
         <h1>Documentation</h1>
-      </ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <p>
-        Welcome to the Fraud AI API documentation. Here you will find all the information you need to integrate our fraud detection service into your applications.
-      </p>
-      <h2>Getting Started</h2>
-      <p>
-        To get started, you need to obtain an API key from the API Keys page. Once you have your key, you can start making requests to our API endpoints.
-      </p>
-      <h2>API Endpoints</h2>
-      <p>
-        Our API has a single endpoint for fraud detection: <code>POST /api/v1/detect</code>
-      </p>
+        <p>
+          Welcome to the Fraud AI API documentation. Here you will find all the information you need to integrate our fraud detection service into your applications.
+        </p>
+      </ion-col>
+    </ion-row>
 
-      <h3>Example Request</h3>
-      <ion-segment [(ngModel)]="selectedLanguage" (ionChange)="selectedLanguage = ($event.detail.value || 'curl')">
-        <ion-segment-button value="curl">cURL</ion-segment-button>
-        <ion-segment-button value="fetch">Fetch</ion-segment-button>
-        <ion-segment-button value="python">Python</ion-segment-button>
-      </ion-segment>
+    <ion-row>
+      <ion-col size="12">
+        <h2>Getting Started</h2>
+        <p>
+          To get started, you need to obtain an API key from the API Keys page. Once you have your key, you can start making requests to our API endpoints.
+        </p>
+      </ion-col>
+    </ion-row>
 
-      <div [ngSwitch]="selectedLanguage" class="ion-margin-top">
-        <app-code-block *ngSwitchCase="'curl'" [code]="curlSnippet" language="bash"></app-code-block>
-        <app-code-block *ngSwitchCase="'fetch'" [code]="fetchSnippet" language="javascript"></app-code-block>
-        <app-code-block *ngSwitchCase="'python'" [code]="pythonSnippet" language="python"></app-code-block>
-      </div>
+    <ion-row>
+      <ion-col size="12">
+        <h2>API Endpoints</h2>
+        <p>
+          Our API has a single endpoint for fraud detection: <code>POST /api/v1/detect</code>
+        </p>
+      </ion-col>
+    </ion-row>
 
-    </ion-card-content>
-  </ion-card>
+    <ion-row>
+      <ion-col size="12">
+        <h3>Example Request</h3>
+        <ion-segment [(ngModel)]="selectedLanguage" (ionChange)="selectedLanguage = ($event.detail.value || 'curl')">
+          <ion-segment-button value="curl">cURL</ion-segment-button>
+          <ion-segment-button value="fetch">Fetch</ion-segment-button>
+          <ion-segment-button value="python">Python</ion-segment-button>
+        </ion-segment>
+
+        <div [ngSwitch]="selectedLanguage" class="ion-margin-top">
+          <app-code-block *ngSwitchCase="'curl'" [code]="curlSnippet" language="bash"></app-code-block>
+          <app-code-block *ngSwitchCase="'fetch'" [code]="fetchSnippet" language="javascript"></app-code-block>
+          <app-code-block *ngSwitchCase="'python'" [code]="pythonSnippet" language="python"></app-code-block>
+        </div>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
 </ion-content>
+

--- a/src/app/pages/docs/docs.component.scss
+++ b/src/app/pages/docs/docs.component.scss
@@ -1,0 +1,30 @@
+ion-grid {
+  ion-row + ion-row {
+    margin-top: 2rem;
+  }
+
+  h1,
+  h2,
+  h3 {
+    font-family: var(--ion-font-family, inherit);
+    color: var(--ion-color-primary);
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  p code {
+    background: var(--ion-color-step-100);
+    color: var(--ion-color-primary);
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-family: var(--ion-font-family-monospace, monospace);
+  }
+
+  ::ng-deep app-code-block .code-block-container {
+    background: var(--ion-color-step-100);
+    color: var(--ion-text-color);
+    border-radius: 8px;
+    font-family: var(--ion-font-family-monospace, monospace);
+  }
+}
+

--- a/src/app/pages/docs/docs.component.ts
+++ b/src/app/pages/docs/docs.component.ts
@@ -3,10 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
   IonContent,
-  IonCard,
-  IonCardHeader,
-  IonCardTitle,
-  IonCardContent,
+  IonGrid,
+  IonRow,
+  IonCol,
   IonSegment,
   IonSegmentButton,
 } from '@ionic/angular/standalone';
@@ -27,10 +26,9 @@ import { environment } from 'src/environments/environment';
     CommonModule,
     FormsModule,
     IonContent,
-    IonCard,
-    IonCardHeader,
-    IonCardTitle,
-    IonCardContent,
+    IonGrid,
+    IonRow,
+    IonCol,
     IonSegment,
     IonSegmentButton,
     CodeBlockComponent,


### PR DESCRIPTION
## Summary
- Replace card layout in docs page with Ionic Grid sections and headings
- Apply theme-based styling to headings and code samples for light and dark modes
- Update docs component imports for new grid layout

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please, set "CHROME_BIN" env variable)*

------
https://chatgpt.com/codex/tasks/task_e_6899c9083500832d952036c0d52ea036