### PR TITLE
Fix theme toggle to use ThemeService setDark

### DIFF
--- a/src/app/pages/layout/layout-header.component.html
+++ b/src/app/pages/layout/layout-header.component.html
@@ -24,7 +24,7 @@
         <ion-icon slot="start" name="key-outline"></ion-icon>
         API Keys
       </ion-button>
-      <ion-toggle (ionChange)="toggleTheme($event)" [checked]="themeService.isDark" aria-label="Toggle dark mode">
+      <ion-toggle (ionChange)="toggleTheme($event)" [checked]="themeService.isDark()" aria-label="Toggle dark mode">
         <ion-icon slot="start" name="sunny-outline"></ion-icon>
         <ion-icon slot="end" name="moon-outline"></ion-icon>
       </ion-toggle>

--- a/src/app/pages/layout/layout-header.component.ts
+++ b/src/app/pages/layout/layout-header.component.ts
@@ -47,7 +47,7 @@ export class LayoutHeaderComponent {
   }
 
   toggleTheme(event: CustomEvent) {
-    this.themeService.toggleDarkTheme(event.detail.checked);
+    this.themeService.setDark(event.detail.checked);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace nonexistent `toggleDarkTheme` call with `setDark` in layout header
- Correct theme toggle binding to call `isDark()`

## Testing
- `npm run lint`
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Chromium requires snap and cannot start)*

------
https://chatgpt.com/codex/tasks/task_e_6899cd112504832d946a44242b2de6df