### PR TITLE
fix: add missing HttpClientTestingModule in layout spec

### DIFF
--- a/src/app/pages/layout/layout.component.spec.ts
+++ b/src/app/pages/layout/layout.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { LayoutPage } from './layout.component';
 
@@ -10,7 +11,7 @@ describe('LayoutPage', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [LayoutPage, RouterTestingModule],
+        imports: [LayoutPage, RouterTestingModule, HttpClientTestingModule],
       }).compileComponents();
 
       fixture = TestBed.createComponent(LayoutPage);


### PR DESCRIPTION
## Summary
- include `HttpClientTestingModule` in `LayoutPage` unit test

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899cf51da84832d9343a002be8b427d