### PR TITLE
ci: add release deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.gitignore
+Dockerfile
+docker-stack.yml

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,0 +1,70 @@
+name: Release Deploy
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build -- --configuration=production
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+
+      - name: Copy stack file
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.SWARM_HOST }}
+          username: ${{ secrets.SWARM_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: docker-stack.yml
+          target: ${{ secrets.SWARM_TARGET_DIR }}
+
+      - name: Deploy stack
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.SWARM_HOST }}
+          username: ${{ secrets.SWARM_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }} \
+            docker stack deploy -c ${{ secrets.SWARM_TARGET_DIR }}/docker-stack.yml \
+              ${{ secrets.SWARM_STACK_NAME }} --with-registry-auth

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: build the Angular/Ionic app
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build -- --configuration=production
+
+# Stage 2: serve the built app with Nginx
+FROM nginx:alpine
+COPY --from=build /app/www /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+  web:
+    image: ${IMAGE}
+    ports:
+      - "80:80"
+    deploy:
+      replicas: 3
+      restart_policy:
+        condition: on-failure
+      update_config:
+        order: start-first


### PR DESCRIPTION
## Summary
- build and push Docker image on release and deploy to swarm via SSH
- add Dockerfile and stack file for containerized frontend

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`
- `npm run build -- --configuration=production`


------
https://chatgpt.com/codex/tasks/task_e_689a0ee2b064832dbaea22040407a80e