### PR TITLE
feat: add signup page

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -47,6 +47,24 @@ describe('AuthService', () => {
     });
   });
 
+  it('should sign up a user and store the token', () => {
+    const mockUser: User = { id: '2', email: 'new@example.com', name: 'New User' };
+    const mockResponse: AuthResponse = { user: mockUser, token: 'new-token' };
+
+    service.signUp({ name: 'New User', email: 'new@example.com', password: 'password' }).subscribe(response => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/v1/auth/sign-up`);
+    expect(req.request.method).toBe('POST');
+    req.flush(mockResponse);
+
+    expect(localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)).toBe('new-token');
+    service.user$.subscribe(user => {
+      expect(user).toEqual(mockUser);
+    });
+  });
+
   it('should sign out a user and remove the token', () => {
     localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, 'test-token');
     service.signOut();

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -39,6 +39,17 @@ export class AuthService {
     );
   }
 
+  signUp(data: { name: string; email: string; password: string }): Observable<AuthResponse> {
+    if (environment.useMock) {
+      const mockUser: User = { id: '1', email: data.email, name: data.name };
+      const mockResponse: AuthResponse = { user: mockUser, token: 'mock.token.123' };
+      return of(mockResponse).pipe(tap((response) => this.setAuth(response)));
+    }
+    return this.http.post<AuthResponse>(`${environment.apiBaseUrl}/v1/auth/sign-up`, data).pipe(
+      tap((response) => this.setAuth(response))
+    );
+  }
+
   me(): Observable<User | null> {
     const token = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
     if (!token) {

--- a/src/app/pages/auth/sign-up/sign-up.component.html
+++ b/src/app/pages/auth/sign-up/sign-up.component.html
@@ -1,3 +1,34 @@
-<p>
-  sign-up works!
-</p>
+<ion-content class="ion-padding">
+  <div class="ion-text-center" style="height: 100%; display: flex; flex-direction: column; justify-content: center;">
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Sign Up</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <form [formGroup]="form" (ngSubmit)="signUp()">
+          <ion-list>
+            <ion-item>
+              <ion-input label="Name" labelPlacement="floating" formControlName="name" required></ion-input>
+            </ion-item>
+            <ion-item>
+              <ion-input label="Email" labelPlacement="floating" formControlName="email" type="email" required></ion-input>
+            </ion-item>
+            <ion-item>
+              <ion-input label="Password" labelPlacement="floating" formControlName="password" type="password" required></ion-input>
+            </ion-item>
+            <ion-item>
+              <ion-input label="Confirm Password" labelPlacement="floating" formControlName="confirmPassword" type="password" required></ion-input>
+            </ion-item>
+          </ion-list>
+          <ion-button type="submit" expand="block" [disabled]="form.invalid || loading">
+            <ion-spinner *ngIf="loading" name="crescent"></ion-spinner>
+            <span *ngIf="!loading">Sign Up</span>
+          </ion-button>
+        </form>
+        <p class="ion-text-center">
+          Already have an account? <a routerLink="/auth/sign-in">Sign In</a>
+        </p>
+      </ion-card-content>
+    </ion-card>
+  </div>
+</ion-content>

--- a/src/app/pages/auth/sign-up/sign-up.component.spec.ts
+++ b/src/app/pages/auth/sign-up/sign-up.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SignUpPage } from './sign-up.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { ToastService } from 'src/app/core/services/toast.service';
 
 describe('SignUpPage', () => {
   let component: SignUpPage;
@@ -8,7 +11,11 @@ describe('SignUpPage', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SignUpPage],
+      imports: [SignUpPage, RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: ToastService, useValue: {} },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SignUpPage);

--- a/src/app/pages/auth/sign-up/sign-up.component.ts
+++ b/src/app/pages/auth/sign-up/sign-up.component.ts
@@ -1,9 +1,85 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators, AbstractControl } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import {
+  IonContent,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonCardContent,
+  IonList,
+  IonItem,
+  IonInput,
+  IonButton,
+  IonSpinner,
+} from '@ionic/angular/standalone';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { ToastService } from 'src/app/core/services/toast.service';
 
 @Component({
   selector: 'app-sign-up',
   templateUrl: './sign-up.component.html',
   styleUrls: ['./sign-up.component.scss'],
   standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterLink,
+    IonContent,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    IonList,
+    IonItem,
+    IonInput,
+    IonButton,
+    IonSpinner,
+  ],
 })
-export class SignUpPage {}
+export class SignUpPage {
+  private fb = inject(FormBuilder);
+  private authService = inject(AuthService);
+  private toastService = inject(ToastService);
+  private router = inject(Router);
+
+  public form = this.fb.group(
+    {
+      name: ['', [Validators.required]],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required]],
+      confirmPassword: ['', [Validators.required]],
+    },
+    { validators: this.passwordMatchValidator }
+  );
+  public loading = false;
+
+  private passwordMatchValidator(control: AbstractControl) {
+    const password = control.get('password')?.value;
+    const confirm = control.get('confirmPassword')?.value;
+    return password === confirm ? null : { mismatch: true };
+  }
+
+  signUp() {
+    if (this.form.invalid) {
+      return;
+    }
+    this.loading = true;
+    const { name, email, password } = this.form.getRawValue();
+    this.authService
+      .signUp({ name: name!, email: email!, password: password! })
+      .subscribe({
+        next: () => {
+          this.loading = false;
+          this.router.navigateByUrl('/playground');
+        },
+        error: () => {
+          this.loading = false;
+          this.toastService.presentError(
+            'Sign up failed. Please check your details and try again.'
+          );
+        },
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- add Ionic signup page with validation and navigation
- support account creation via new `signUp` method in AuthService
- cover signup flow with updated unit tests

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot start ChromeHeadless - requires snap install)*

------
https://chatgpt.com/codex/tasks/task_e_689a0e301dc8832db76faf483279edb5