### PR TITLE
feat: improve responsive layout and hero

### DIFF
--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -6,6 +6,8 @@ ion-content, .hero {
   display: flex;
   align-items: center;
   padding: 2rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .hero-text {
@@ -65,5 +67,15 @@ ion-content, .hero {
 
   .hero-image {
     margin-top: 0;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero-text h1 {
+    font-size: 4.5rem;
+  }
+
+  .hero-text p {
+    font-size: 1.5rem;
   }
 }

--- a/src/app/pages/layout/layout-header.component.html
+++ b/src/app/pages/layout/layout-header.component.html
@@ -7,20 +7,20 @@
     <ion-title>Fraud AI</ion-title>
 
     <ion-buttons slot="end">
-      <ion-button routerLink="/">
+      <ion-button routerLink="/" class="nav-link">
         <ion-icon slot="start" name="home-outline"></ion-icon>
         Home
       </ion-button>
-      <ion-button routerLink="/docs">
+      <ion-button routerLink="/docs" class="nav-link">
         <ion-icon slot="start" name="document-text-outline"></ion-icon>
         Docs
       </ion-button>
-      <ion-button routerLink="/playground">
+      <ion-button routerLink="/playground" class="nav-link">
         <ion-icon slot="start" name="flask-outline"></ion-icon>
         Playground
         <ion-badge *ngIf="apiKeyService.isApiKeyActive$ | async" color="success" style="margin-left: 8px;">API Key Active</ion-badge>
       </ion-button>
-      <ion-button routerLink="/keys" *ngIf="authService.user$ | async">
+      <ion-button routerLink="/keys" *ngIf="authService.user$ | async" class="nav-link">
         <ion-icon slot="start" name="key-outline"></ion-icon>
         API Keys
       </ion-button>

--- a/src/app/pages/layout/layout-header.component.scss
+++ b/src/app/pages/layout/layout-header.component.scss
@@ -1,0 +1,16 @@
+ion-buttons[slot='end'] {
+  display: flex;
+  align-items: center;
+}
+
+@media (max-width: 767px) {
+  ion-buttons[slot='end'] .nav-link {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  ion-menu-button {
+    display: none;
+  }
+}

--- a/src/app/pages/layout/layout.component.html
+++ b/src/app/pages/layout/layout.component.html
@@ -1,4 +1,42 @@
-<app-layout-header></app-layout-header>
-<ion-content>
-  <ion-router-outlet></ion-router-outlet>
-</ion-content>
+<ion-menu content-id="main-content">
+  <ion-header>
+    <ion-toolbar color="primary">
+      <ion-title>Menu</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-list>
+      <ion-menu-toggle auto-hide="true">
+        <ion-item routerLink="/" routerDirection="root">
+          <ion-icon slot="start" name="home-outline"></ion-icon>
+          <ion-label>Home</ion-label>
+        </ion-item>
+      </ion-menu-toggle>
+      <ion-menu-toggle auto-hide="true">
+        <ion-item routerLink="/docs">
+          <ion-icon slot="start" name="document-text-outline"></ion-icon>
+          <ion-label>Docs</ion-label>
+        </ion-item>
+      </ion-menu-toggle>
+      <ion-menu-toggle auto-hide="true">
+        <ion-item routerLink="/playground">
+          <ion-icon slot="start" name="flask-outline"></ion-icon>
+          <ion-label>Playground</ion-label>
+        </ion-item>
+      </ion-menu-toggle>
+      <ion-menu-toggle auto-hide="true">
+        <ion-item routerLink="/keys">
+          <ion-icon slot="start" name="key-outline"></ion-icon>
+          <ion-label>API Keys</ion-label>
+        </ion-item>
+      </ion-menu-toggle>
+    </ion-list>
+  </ion-content>
+</ion-menu>
+
+<div id="main-content">
+  <app-layout-header></app-layout-header>
+  <ion-content>
+    <ion-router-outlet></ion-router-outlet>
+  </ion-content>
+</div>

--- a/src/app/pages/layout/layout.component.scss
+++ b/src/app/pages/layout/layout.component.scss
@@ -1,4 +1,4 @@
-:host {
+:host { 
   display: block;
 }
 
@@ -24,4 +24,8 @@
 
 :host ::ng-deep ion-toggle {
   margin: 0 8px;
+}
+
+#main-content {
+  height: 100%;
 }

--- a/src/app/pages/layout/layout.component.ts
+++ b/src/app/pages/layout/layout.component.ts
@@ -1,5 +1,17 @@
 import { Component } from '@angular/core';
-import { IonContent, IonRouterOutlet } from '@ionic/angular/standalone';
+import {
+  IonContent,
+  IonRouterOutlet,
+  IonMenu,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonList,
+  IonItem,
+  IonIcon,
+  IonLabel,
+  IonMenuToggle,
+} from '@ionic/angular/standalone';
 import { LayoutHeaderComponent } from './layout-header.component';
 
 @Component({
@@ -7,7 +19,20 @@ import { LayoutHeaderComponent } from './layout-header.component';
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.scss'],
   standalone: true,
-  imports: [IonContent, IonRouterOutlet, LayoutHeaderComponent],
+  imports: [
+    IonContent,
+    IonRouterOutlet,
+    IonMenu,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonList,
+    IonItem,
+    IonIcon,
+    IonLabel,
+    IonMenuToggle,
+    LayoutHeaderComponent,
+  ],
 })
 export class LayoutPage {}
 


### PR DESCRIPTION
## Summary
- add responsive navigation menu with side drawer for small screens
- enhance landing hero layout for wider displays
- hide toolbar links on mobile for cleaner header

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a0dd3e0f0832db9c1b43ebb3989ef