### PR TITLE
Improve auth form design and responsiveness

### DIFF
--- a/src/app/pages/auth/sign-in/sign-in.component.html
+++ b/src/app/pages/auth/sign-in/sign-in.component.html
@@ -1,12 +1,12 @@
 <ion-content class="ion-padding">
-  <div class="ion-text-center" style="height: 100%; display: flex; flex-direction: column; justify-content: center;">
-    <ion-card>
+  <div class="auth-container">
+    <ion-card class="auth-card">
       <ion-card-header>
         <ion-card-title>Sign In</ion-card-title>
       </ion-card-header>
       <ion-card-content>
         <form [formGroup]="form" (ngSubmit)="signIn()">
-          <ion-list>
+          <ion-list lines="none">
             <ion-item>
               <ion-input label="Email" labelPlacement="floating" formControlName="email" type="email" required></ion-input>
             </ion-item>

--- a/src/app/pages/auth/sign-in/sign-in.component.scss
+++ b/src/app/pages/auth/sign-in/sign-in.component.scss
@@ -1,0 +1,27 @@
+@use 'sass:map';
+
+.auth-container {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 320px;
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .auth-card {
+    max-width: 480px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .auth-card {
+    max-width: 600px;
+  }
+}
+

--- a/src/app/pages/auth/sign-up/sign-up.component.html
+++ b/src/app/pages/auth/sign-up/sign-up.component.html
@@ -1,12 +1,12 @@
 <ion-content class="ion-padding">
-  <div class="ion-text-center" style="height: 100%; display: flex; flex-direction: column; justify-content: center;">
-    <ion-card>
+  <div class="auth-container">
+    <ion-card class="auth-card">
       <ion-card-header>
         <ion-card-title>Sign Up</ion-card-title>
       </ion-card-header>
       <ion-card-content>
         <form [formGroup]="form" (ngSubmit)="signUp()">
-          <ion-list>
+          <ion-list lines="none">
             <ion-item>
               <ion-input label="Name" labelPlacement="floating" formControlName="name" required></ion-input>
             </ion-item>

--- a/src/app/pages/auth/sign-up/sign-up.component.scss
+++ b/src/app/pages/auth/sign-up/sign-up.component.scss
@@ -1,0 +1,27 @@
+@use 'sass:map';
+
+.auth-container {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 320px;
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .auth-card {
+    max-width: 480px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .auth-card {
+    max-width: 600px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Center authentication cards and remove inline styling
- Add responsive breakpoints for auth forms on mobile, tablet, and desktop
- Clean up ion-list styling on sign-in and sign-up pages

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a17f9aef0832db9b35eb8dde05b66