### PR TITLE
feat: add syntax highlighting to docs code samples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@capacitor/keyboard": "7.0.2",
         "@capacitor/status-bar": "7.0.2",
         "@ionic/angular": "^8.0.0",
+        "highlight.js": "^11.11.1",
         "ionicons": "^7.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -10961,6 +10962,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hosted-git-info": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@capacitor/keyboard": "7.0.2",
     "@capacitor/status-bar": "7.0.2",
     "@ionic/angular": "^8.0.0",
+    "highlight.js": "^11.11.1",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/app/shared/components/code-block/code-block.component.html
+++ b/src/app/shared/components/code-block/code-block.component.html
@@ -1,4 +1,4 @@
 <div class="code-block-container">
-  <pre><code [class]="'language-' + language">{{ code }}</code></pre>
+  <pre><code #codeElement [class]="'language-' + language">{{ code }}</code></pre>
   <app-copy-button [textToCopy]="code"></app-copy-button>
 </div>

--- a/src/app/shared/components/code-block/code-block.component.ts
+++ b/src/app/shared/components/code-block/code-block.component.ts
@@ -1,6 +1,14 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, AfterViewInit, OnChanges, ViewChild, ElementRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CopyButtonComponent } from '../copy-button/copy-button.component';
+import hljs from 'highlight.js/lib/core';
+import bash from 'highlight.js/lib/languages/bash';
+import javascript from 'highlight.js/lib/languages/javascript';
+import python from 'highlight.js/lib/languages/python';
+
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('python', python);
 
 @Component({
   selector: 'app-code-block',
@@ -9,7 +17,24 @@ import { CopyButtonComponent } from '../copy-button/copy-button.component';
   standalone: true,
   imports: [CommonModule, CopyButtonComponent],
 })
-export class CodeBlockComponent {
+export class CodeBlockComponent implements AfterViewInit, OnChanges {
   @Input() code = '';
   @Input() language = 'typescript';
+  @ViewChild('codeElement') codeElement?: ElementRef<HTMLElement>;
+
+  ngAfterViewInit() {
+    this.highlight();
+  }
+
+  ngOnChanges() {
+    this.highlight();
+  }
+
+  private highlight() {
+    setTimeout(() => {
+      if (this.codeElement) {
+        hljs.highlightElement(this.codeElement.nativeElement);
+      }
+    });
+  }
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -25,6 +25,8 @@
 @import "@ionic/angular/css/text-transformation.css";
 @import "@ionic/angular/css/flex-utils.css";
 
+@import "highlight.js/styles/github-dark.css";
+
 /**
  * Ionic Dark Mode
  * -----------------------------------------------------


### PR DESCRIPTION
## Summary
- add highlight.js dependency and theme
- highlight bash, javascript, and python examples in code block component

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689a2b51f8d4832d8713e9fbae838412