### PR TITLE
Handle authentication HTTP errors

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -47,6 +47,26 @@ describe('AuthService', () => {
     });
   });
 
+  it('should propagate sign in errors', () => {
+    const errorMessage = 'Invalid credentials';
+
+    service.signIn({ email: 'test@example.com', password: 'wrong' }).subscribe({
+      next: () => fail('should have failed with an error'),
+      error: (err) => {
+        expect(err).toBe(errorMessage);
+      },
+    });
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/v1/auth/sign-in`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ message: errorMessage }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)).toBeNull();
+    service.user$.subscribe((user) => {
+      expect(user).toBeNull();
+    });
+  });
+
   it('should sign up a user and store the token', () => {
     const mockUser: User = { id: '2', email: 'new@example.com', name: 'New User' };
     const mockResponse: AuthResponse = { user: mockUser, token: 'new-token' };
@@ -62,6 +82,28 @@ describe('AuthService', () => {
     expect(localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)).toBe('new-token');
     service.user$.subscribe(user => {
       expect(user).toEqual(mockUser);
+    });
+  });
+
+  it('should propagate sign up errors', () => {
+    const errorMessage = 'Sign up failed';
+
+    service
+      .signUp({ name: 'New User', email: 'new@example.com', password: 'password' })
+      .subscribe({
+        next: () => fail('should have failed with an error'),
+        error: (err) => {
+          expect(err).toBe(errorMessage);
+        },
+      });
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/v1/auth/sign-up`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ message: errorMessage }, { status: 400, statusText: 'Bad Request' });
+
+    expect(localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)).toBeNull();
+    service.user$.subscribe((user) => {
+      expect(user).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- propagate HTTP errors in `AuthService` via new `handleError` helper
- add tests for sign-in and sign-up error cases

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689ae318e234832da684535a5c91af2b