### PR TITLE
fix missing rxjs import in auth service

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { tap, catchError, switchMap } from 'rxjs/operators';
-import { BehaviorSubject, Observable, of, throwError } from 'rxjs';
+import { BehaviorSubject, Observable, of, throwError, from } from 'rxjs';
 import { User } from '../models/user.model';
 import { AuthResponse } from '../models/auth-response.model';
 import { environment } from '../../../environments/environment';


### PR DESCRIPTION
## Summary
- import `from` from rxjs in AuthService to resolve missing reference

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689af1be73e8832d848c8385523813ce