### PR TITLE
fix: enable router links in mobile menu

### DIFF
--- a/src/app/pages/layout/layout.component.ts
+++ b/src/app/pages/layout/layout.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import {
   IonContent,
   IonRouterOutlet,
@@ -20,6 +21,7 @@ import { LayoutHeaderComponent } from './layout-header.component';
   styleUrls: ['./layout.component.scss'],
   standalone: true,
   imports: [
+    RouterLink,
     IonContent,
     IonRouterOutlet,
     IonMenu,


### PR DESCRIPTION
## Summary
- import RouterLink and include it in layout component so menu items navigate correctly

## Testing
- `npm test -- --watch=false --no-progress` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b1e5721b4832d91901fe746fafd1b