### PR TITLE
chore: remove unused ionic imports

### DIFF
--- a/src/app/pages/api-keys/api-keys.component.ts
+++ b/src/app/pages/api-keys/api-keys.component.ts
@@ -1,16 +1,9 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import {
-  IonHeader,
-  IonToolbar,
-  IonTitle,
   IonContent,
   IonButton,
   IonIcon,
-  IonButtons,
-  IonList,
-  IonItem,
-  IonLabel,
 } from '@ionic/angular/standalone';
 import { AlertController, ModalController } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
@@ -37,16 +30,9 @@ export interface ApiKey {
   imports: [
     CommonModule,
     DatePipe,
-    IonHeader,
-    IonToolbar,
-    IonTitle,
     IonContent,
     IonButton,
     IonIcon,
-    IonButtons,
-    IonList,
-    IonItem,
-    IonLabel,
     CardComponent,
   ],
 })


### PR DESCRIPTION
## Summary
- remove unused Ionic components from API key page

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cd7680cb4832d92139431b4f31818