### PR TITLE
refactor: remove grid imports from docs component

### DIFF
--- a/src/app/pages/docs/docs.component.ts
+++ b/src/app/pages/docs/docs.component.ts
@@ -3,9 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
   IonContent,
-  IonGrid,
-  IonRow,
-  IonCol,
   IonSegment,
   IonSegmentButton,
 } from '@ionic/angular/standalone';
@@ -27,9 +24,6 @@ import { CalloutComponent } from 'src/app/shared/components/callout/callout.comp
     CommonModule,
     FormsModule,
     IonContent,
-    IonGrid,
-    IonRow,
-    IonCol,
     IonSegment,
     IonSegmentButton,
     CodeBlockComponent,


### PR DESCRIPTION
## Summary
- remove IonGrid, IonRow, and IonCol from Docs component imports

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cd7673c9c832db5321993a3b0f4a5