### PR TITLE
refactor: remove IonBadge from layout header

### DIFF
--- a/src/app/pages/layout/layout-header.component.ts
+++ b/src/app/pages/layout/layout-header.component.ts
@@ -8,7 +8,6 @@ import {
   IonMenuButton,
   IonButton,
   IonIcon,
-  IonBadge,
 } from '@ionic/angular/standalone';
 
 import { AuthService } from 'src/app/core/services/auth.service';
@@ -32,7 +31,6 @@ import { logInOutline, logOutOutline, keyOutline } from 'ionicons/icons';
     IonMenuButton,
     IonButton,
     IonIcon,
-    IonBadge,
     BrandLogoComponent,
     ThemeToggleComponent,
   ],


### PR DESCRIPTION
## Summary
- remove IonBadge from `LayoutHeaderComponent` imports and component config

## Testing
- `npm test -- --watch=false --progress=false --browsers=ChromeHeadless` *(fails: Cannot find name 'CardComponent' in other modules)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cd751acb4832d874ffd8798c1de93