### PR TITLE
Remove IonImg from landing component imports

### DIFF
--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -6,7 +6,6 @@ import {
   IonGrid,
   IonRow,
   IonCol,
-  IonImg,
   IonIcon,
 } from '@ionic/angular/standalone';
 import { CardComponent } from '../../shared/components/card/card.component';
@@ -25,7 +24,6 @@ import { shieldCheckmarkOutline, codeSlashOutline, analyticsOutline, serverOutli
     IonGrid,
     IonRow,
     IonCol,
-    IonImg,
     IonIcon,
     CardComponent,
   ],


### PR DESCRIPTION
## Summary
- remove unused IonImg import from landing component

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: process hangs without output)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cd765de8c832d8511acc8457f3b23