### PR TITLE
test: fix ThemeService and ApiKeysComponent specs

### DIFF
--- a/src/app/core/services/theme.service.spec.ts
+++ b/src/app/core/services/theme.service.spec.ts
@@ -1,26 +1,31 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ThemeService } from './theme.service';
 import { DOCUMENT } from '@angular/common';
+import { PLATFORM_ID } from '@angular/core';
+import { ThemeService } from './theme.service';
 import { STORAGE_KEYS } from '../constants';
 
 describe('ThemeService', () => {
-  let service: ThemeService;
   let documentRef: Document;
 
   beforeEach(() => {
     localStorage.removeItem(STORAGE_KEYS.THEME);
     TestBed.configureTestingModule({
-      providers: [ThemeService]
+      providers: [{ provide: PLATFORM_ID, useValue: 'browser' }],
     });
-    service = TestBed.inject(ThemeService);
     documentRef = TestBed.inject(DOCUMENT);
   });
 
+  function createService(): ThemeService {
+    return TestBed.runInInjectionContext(() => new ThemeService());
+  }
+
   it('should be created', () => {
+    const service = createService();
     expect(service).toBeTruthy();
   });
 
   it('should toggle theme and persist choice', fakeAsync(() => {
+    const service = createService();
     // Set a predictable start state for the test
     service.theme.set('light');
     tick(); // Let the effect run once to set initial state
@@ -44,8 +49,7 @@ describe('ThemeService', () => {
 
   it('should initialize from localStorage if a theme is stored', () => {
     localStorage.setItem(STORAGE_KEYS.THEME, 'dark');
-    // Create a new service to test initialization
-    const newService = TestBed.inject(ThemeService);
+    const newService = createService();
     expect(newService.theme()).toBe('dark');
   });
 });

--- a/src/app/pages/api-keys/api-keys.component.spec.ts
+++ b/src/app/pages/api-keys/api-keys.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { AlertController } from '@ionic/angular';
+import { AlertController, ModalController } from '@ionic/angular';
 import { ApiKeysComponent } from './api-keys.component';
 import { ToastService } from 'src/app/core/services/toast.service';
 
@@ -12,6 +12,7 @@ describe('ApiKeysComponent', () => {
       imports: [ApiKeysComponent],
       providers: [
         { provide: AlertController, useValue: { create: () => Promise.resolve({ present: () => Promise.resolve() }) } },
+        { provide: ModalController, useValue: {} },
         { provide: ToastService, useValue: { present: () => Promise.resolve() } },
       ],
     }).compileComponents();


### PR DESCRIPTION
## Summary
- refactor ThemeService tests to create fresh instances and run in browser platform
- stub ModalController in ApiKeysComponent tests to satisfy DI

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test -- --watch=false --browsers=ChromeHeadless` (fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)


------
https://chatgpt.com/codex/tasks/task_e_689cdc39ceec832d869c0fc034bdfb87