### PR TITLE
Fix ApiKeysComponent unit test ModalController provider

### DIFF
--- a/src/app/pages/api-keys/api-keys.component.spec.ts
+++ b/src/app/pages/api-keys/api-keys.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { AlertController, ModalController } from '@ionic/angular';
+import { AlertController, ModalController } from '@ionic/angular/standalone';
 import { ApiKeysComponent } from './api-keys.component';
 import { ToastService } from 'src/app/core/services/toast.service';
 


### PR DESCRIPTION
## Summary
- use Ionic standalone controllers in `ApiKeysComponent` unit test

## Testing
- `CHROME_BIN=/tmp/chrome-headless.sh npm test -- --watch=false --browsers=ChromeHeadless`


------
https://chatgpt.com/codex/tasks/task_e_689cdf17d858832d9b5fcb212bba0893