### PR TITLE
Remove scope column from API keys page

### DIFF
--- a/src/app/pages/api-keys/api-keys.component.html
+++ b/src/app/pages/api-keys/api-keys.component.html
@@ -16,7 +16,6 @@
             <tr>
               <th>Name</th>
               <th>Key</th>
-              <th>Scopes</th>
               <th>Created</th>
               <th>Last Used</th>
               <th></th>
@@ -31,11 +30,6 @@
                   <ion-button fill="clear" size="small" (click)="copyKey(key.key)">
                     <ion-icon slot="icon-only" name="copy-outline"></ion-icon>
                   </ion-button>
-                </div>
-              </td>
-              <td>
-                <div class="scopes-cell">
-                  <span *ngFor="let scope of key.scopes" class="scope-badge">{{ scope }}</span>
                 </div>
               </td>
               <td>{{ key.createdAt | date:'mediumDate' }}</td>

--- a/src/app/pages/api-keys/api-keys.component.scss
+++ b/src/app/pages/api-keys/api-keys.component.scss
@@ -51,18 +51,6 @@ tbody tr:last-child td {
   font-family: 'JetBrains Mono', monospace;
 }
 
-.scopes-cell {
-  display: flex;
-  gap: var(--space-2);
-}
-
-.scope-badge {
-  display: inline-block;
-  padding: var(--space-1) var(--space-2);
-  background-color: hsl(var(--surface-2-hsl));
-  border-radius: var(--radius-sm);
-  font-weight: 500;
-}
 
 .empty-state {
   padding: var(--space-7) var(--space-5);

--- a/src/app/pages/api-keys/api-keys.component.ts
+++ b/src/app/pages/api-keys/api-keys.component.ts
@@ -17,7 +17,6 @@ export interface ApiKey {
   name: string;
   key: string;
   prefix: string;
-  scopes: string[];
   createdAt: Date;
   lastUsed: Date | null;
 }
@@ -38,8 +37,8 @@ export interface ApiKey {
 })
 export class ApiKeysComponent {
   public apiKeys: ApiKey[] = [
-    { name: 'My First Key', key: 'sk_live_123abcde', prefix: 'sk_live_...', scopes: ['read', 'write'], createdAt: new Date(), lastUsed: new Date(Date.now() - 1000 * 60 * 60 * 24) },
-    { name: 'Marketing Campaign Key', key: 'sk_live_456fghij', prefix: 'sk_live_...', scopes: ['read'], createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7), lastUsed: null },
+    { name: 'My First Key', key: 'sk_live_123abcde', prefix: 'sk_live_...', createdAt: new Date(), lastUsed: new Date(Date.now() - 1000 * 60 * 60 * 24) },
+    { name: 'Marketing Campaign Key', key: 'sk_live_456fghij', prefix: 'sk_live_...', createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7), lastUsed: null },
   ];
 
   private alertCtrl = inject(AlertController);
@@ -63,7 +62,6 @@ export class ApiKeysComponent {
         name: data.name || 'New API Key',
         key: `sk_live_${Math.random().toString(36).substring(2)}`,
         prefix: `sk_live_...${Math.random().toString(36).substring(9, 13)}`,
-        scopes: data.scopes,
         createdAt: new Date(),
         lastUsed: null,
       };

--- a/src/app/pages/api-keys/generate-key-modal/generate-key-modal.component.html
+++ b/src/app/pages/api-keys/generate-key-modal/generate-key-modal.component.html
@@ -9,19 +9,10 @@
   </ion-toolbar>
 </ion-header>
 <ion-content class="ion-padding">
-  <p>Give your key a descriptive name and select the scopes it should have access to.</p>
+  <p>Give your key a descriptive name.</p>
   <ion-list>
     <ion-item>
       <ion-input label="Key Name" label-placement="stacked" [(ngModel)]="name" placeholder="e.g., My Web App"></ion-input>
-    </ion-item>
-    <ion-item lines="none">
-      <ion-label>Scopes</ion-label>
-    </ion-item>
-    <ion-item>
-      <ion-checkbox [(ngModel)]="scopes.read" labelPlacement="end">Read Access</ion-checkbox>
-    </ion-item>
-    <ion-item>
-      <ion-checkbox [(ngModel)]="scopes.write" labelPlacement="end">Write Access</ion-checkbox>
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="confirm()" [disabled]="!name" class="ion-margin-top">Generate Key</ion-button>

--- a/src/app/pages/api-keys/generate-key-modal/generate-key-modal.component.ts
+++ b/src/app/pages/api-keys/generate-key-modal/generate-key-modal.component.ts
@@ -12,8 +12,6 @@ import {
   IonInput,
   IonButton,
   IonIcon,
-  IonCheckbox,
-  IonLabel,
   IonButtons,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
@@ -35,14 +33,11 @@ import { close } from 'ionicons/icons';
     IonInput,
     IonButton,
     IonIcon,
-    IonCheckbox,
-    IonLabel,
     IonButtons,
   ],
 })
 export class GenerateKeyModalComponent {
   public name = '';
-  public scopes = { read: false, write: false };
   private modalCtrl = inject(ModalController);
 
   constructor() {
@@ -54,9 +49,6 @@ export class GenerateKeyModalComponent {
   }
 
   confirm() {
-    const selectedScopes = Object.entries(this.scopes)
-      .filter(([, checked]) => checked)
-      .map(([scope]) => scope);
-    return this.modalCtrl.dismiss({ name: this.name, scopes: selectedScopes }, 'confirm');
+    return this.modalCtrl.dismiss({ name: this.name }, 'confirm');
   }
 }


### PR DESCRIPTION
## Summary
- remove scopes column from API keys table
- drop scope selection from API key creation modal and type

## Testing
- `npm run lint`
- `NG_CLI_ANALYTICS=false npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689dc83f3f68832db9b79f566403a727