### PR TITLE
fix: persist auth token across refresh

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,18 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
+import { authInterceptor } from './app/core/interceptors/auth.interceptor';
+import { errorInterceptor } from './app/core/interceptors/error.interceptor';
 
 bootstrapApplication(AppComponent, {
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
-    provideHttpClient(withInterceptorsFromDi()),
+    provideHttpClient(withInterceptors([authInterceptor, errorInterceptor])),
   ],
 });


### PR DESCRIPTION
## Summary
- register auth and error interceptors with Angular bootstrap so auth token is sent on every request

## Testing
- `CI=1 npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_689dc98511b0832db5b15f5769f3ed94