### PR TITLE
fix: add bottom padding to app container

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -138,11 +138,13 @@ pre code {
   max-width: 1280px;
   margin-inline: auto;
   padding-inline: var(--space-6);
+  padding-block-end: var(--space-8);
 }
 
 @media (max-width: 768px) {
   .app-container {
     padding-inline: var(--space-4);
+    padding-block-end: var(--space-8);
   }
 }
 


### PR DESCRIPTION
## Summary
- add bottom padding to `.app-container` for more space after content
- ensure mobile breakpoint also includes bottom spacing

## Testing
- `npm run build`
- `npx ng test --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689dd63d1ab0832db7944d9c2e06ad91