### PR TITLE
Load API keys from backend

### DIFF
--- a/src/app/pages/api-keys/api-keys.component.html
+++ b/src/app/pages/api-keys/api-keys.component.html
@@ -14,7 +14,7 @@
         <table>
           <thead>
             <tr>
-              <th>Name</th>
+              <th>Label</th>
               <th>Key</th>
               <th>Created</th>
               <th>Last Used</th>
@@ -23,7 +23,7 @@
           </thead>
           <tbody>
             <tr *ngFor="let key of apiKeys">
-              <td>{{ key.name }}</td>
+              <td>{{ key.label }}</td>
               <td>
                 <div class="key-cell">
                   <span>{{ key.prefix }}</span>
@@ -33,7 +33,7 @@
                 </div>
               </td>
               <td>{{ key.createdAt | date:'mediumDate' }}</td>
-              <td>{{ key.lastUsed ? (key.lastUsed | date:'mediumDate') : 'Never' }}</td>
+              <td>{{ key.lastUsedAt ? (key.lastUsedAt | date:'mediumDate') : 'Never' }}</td>
               <td>
                 <ion-button fill="clear" size="small" color="danger" (click)="revokeKey(key)">
                   <ion-icon slot="icon-only" name="trash"></ion-icon>

--- a/src/app/pages/api-keys/api-keys.component.spec.ts
+++ b/src/app/pages/api-keys/api-keys.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { AlertController, ModalController } from '@ionic/angular/standalone';
 import { ApiKeysComponent } from './api-keys.component';
 import { ToastService } from 'src/app/core/services/toast.service';
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
 
 describe('ApiKeysComponent', () => {
   let component: ApiKeysComponent;
@@ -14,6 +16,7 @@ describe('ApiKeysComponent', () => {
         { provide: AlertController, useValue: { create: () => Promise.resolve({ present: () => Promise.resolve() }) } },
         { provide: ModalController, useValue: {} },
         { provide: ToastService, useValue: { present: () => Promise.resolve() } },
+        { provide: HttpClient, useValue: { get: () => of([]) } },
       ],
     }).compileComponents();
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://api.fraud.ai/api', // Example production API URL
+  apiBaseUrl: 'https://api.fraud.ai', // Example production API URL
   useMock: false,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8000/api',
+  apiBaseUrl: 'http://localhost:8080',
   useMock: true,
 };


### PR DESCRIPTION
## Summary
- fetch API keys from backend on `/keys` page load
- show label, masked key, creation and last-used dates
- point API base URL to new root endpoints

## Testing
- `npm test` *(fails: No binary for Chrome browser on platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de30b6e00832d9484bc355244ca35