### PR TITLE
feat: wire playground to prediction api

### DIFF
--- a/src/app/core/services/model-selector.service.spec.ts
+++ b/src/app/core/services/model-selector.service.spec.ts
@@ -3,6 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { ModelSelectorService } from './model-selector.service';
+import { environment } from 'src/environments/environment';
 
 describe('ModelSelectorService', () => {
   let service: ModelSelectorService;
@@ -16,7 +17,7 @@ describe('ModelSelectorService', () => {
     httpMock = TestBed.inject(HttpTestingController);
 
     httpMock
-      .expectOne('http://localhost:8000/api/v1/inference/models')
+      .expectOne(`${environment.apiBaseUrl}/v1/inference/models`)
       .flush({ models: [] });
   });
 

--- a/src/app/pages/docs/docs.component.spec.ts
+++ b/src/app/pages/docs/docs.component.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/common/http/testing';
 
 import { DocsPage } from './docs.component';
+import { environment } from 'src/environments/environment';
 
 describe('DocsPage', () => {
   let component: DocsPage;
@@ -23,7 +24,7 @@ describe('DocsPage', () => {
 
       fixture = TestBed.createComponent(DocsPage);
       httpMock
-        .expectOne('http://localhost:8000/api/v1/inference/models')
+        .expectOne(`${environment.apiBaseUrl}/v1/inference/models`)
         .flush({ models: [] });
 
       component = fixture.componentInstance;

--- a/src/app/pages/playground/playground.component.spec.ts
+++ b/src/app/pages/playground/playground.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 
 import { PlaygroundComponent } from './playground.component';
@@ -19,7 +20,7 @@ describe('PlaygroundComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [PlaygroundComponent],
+      imports: [PlaygroundComponent, HttpClientTestingModule],
       providers: [{ provide: ModelSelectorService, useClass: MockModelSelectorService }],
     }).compileComponents();
 


### PR DESCRIPTION
## Summary
- integrate backend prediction endpoint into playground page
- send selected model and user-provided features to /v1/inference/predict
- update unit test setup for HttpClient

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de87f63ac832dbe875284a5458639