### PR TITLE
feat(api-keys): revoke keys via API

### DIFF
--- a/src/app/pages/api-keys/api-keys.component.spec.ts
+++ b/src/app/pages/api-keys/api-keys.component.spec.ts
@@ -16,7 +16,7 @@ describe('ApiKeysComponent', () => {
         { provide: AlertController, useValue: { create: () => Promise.resolve({ present: () => Promise.resolve() }) } },
         { provide: ModalController, useValue: {} },
         { provide: ToastService, useValue: { present: () => Promise.resolve() } },
-        { provide: HttpClient, useValue: { get: () => of([]) } },
+        { provide: HttpClient, useValue: { get: () => of([]), delete: () => of(null) } },
       ],
     }).compileComponents();
 


### PR DESCRIPTION
## Summary
- store API key id and update data mappings
- call DELETE /v1/apikeys/:id to revoke keys with error handling
- adjust tests for new HttpClient.delete call

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c3f5e60832d90f1dbf615366eeb