### PR TITLE
fix playground payload

### DIFF
--- a/src/app/pages/playground/playground.component.spec.ts
+++ b/src/app/pages/playground/playground.component.spec.ts
@@ -1,22 +1,35 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 
 import { PlaygroundComponent } from './playground.component';
 import { ModelSelectorService } from 'src/app/core/services/model-selector.service';
+import { Model } from 'src/app/core/models/model.model';
+import { environment } from 'src/environments/environment';
+
+const mockModel: Model = {
+  id: 'run-id-1',
+  model_type: 'logreg',
+  name: 'FraudDetector-logistic_regression',
+  version: '1',
+  stage: 'None',
+  run_id: 'run-id-1',
+  signature_inputs: ['transaction_id', 'amount', 'merchant_type', 'device_type'],
+};
 
 class MockModelSelectorService {
-  availableModels$ = of([]);
-  selectedModel$ = of(null);
+  availableModels$ = of([mockModel]);
+  selectedModel$ = of(mockModel);
   setSelectedModel() {}
   getSelectedModel() {
-    return null;
+    return mockModel;
   }
 }
 
 describe('PlaygroundComponent', () => {
   let component: PlaygroundComponent;
   let fixture: ComponentFixture<PlaygroundComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -26,10 +39,45 @@ describe('PlaygroundComponent', () => {
 
     fixture = TestBed.createComponent(PlaygroundComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   }));
 
+  afterEach(() => {
+    httpMock.verify();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should send model_type and required features', () => {
+    component.requestBody = JSON.stringify(
+      {
+        transaction_id: 9876543210,
+        amount: 200.12,
+        merchant_type: 'electronics',
+        device_type: 'laptop',
+        extra_field: 'ignore',
+      },
+      null,
+      2,
+    );
+
+    component.runInference();
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/v1/inference/predict`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      model: 'logreg',
+      features: {
+        transaction_id: 9876543210,
+        amount: 200.12,
+        merchant_type: 'electronics',
+        device_type: 'laptop',
+      },
+    });
+
+    req.flush({});
   });
 });

--- a/src/app/pages/playground/playground.component.ts
+++ b/src/app/pages/playground/playground.component.ts
@@ -58,7 +58,8 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
 
   public availableModels: Model[] = [];
   public selectedModelId: string | null = null;
-  public requestBody = '{\n  "amount": 120.50,\n  "currency": "USD",\n  "user_id": "user-12345"\n}';
+  public requestBody =
+    '{\n  "transaction_id": 9876543210,\n  "amount": 200.12,\n  "device_type": "laptop",\n  "merchant_type": "electronics"\n}';
   public responseBody = '';
   public responseStatus = '';
   public responseLatency = 0;
@@ -108,9 +109,27 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const selectedModel = this.modelSelectorService.getSelectedModel();
+    if (!selectedModel) {
+      this.responseStatus = 'No model selected';
+      this.isLoading = false;
+      return;
+    }
+
+    const requiredFields = selectedModel.signature_inputs;
+    const missingFields = requiredFields.filter(f => !(f in features));
+    if (missingFields.length) {
+      this.responseStatus = `Missing fields: ${missingFields.join(', ')}`;
+      this.isLoading = false;
+      return;
+    }
+
+    const filteredFeatures: any = {};
+    requiredFields.forEach(key => (filteredFeatures[key] = features[key]));
+
     const payload = {
-      model: this.modelSelectorService.getSelectedModel()?.id,
-      features,
+      model: selectedModel.model_type,
+      features: filteredFeatures,
     };
 
     const startTime = Date.now();
@@ -175,13 +194,10 @@ export class PlaygroundComponent implements OnInit, OnDestroy {
   loadExample() {
     this.requestBody = JSON.stringify(
       {
-        amount: 99.99,
-        currency: 'EUR',
-        user_id: 'user-67890',
-        metadata: {
-          device_id: 'abc-123',
-          ip_address: '123.45.67.89',
-        },
+        transaction_id: 9876543210,
+        amount: 200.12,
+        device_type: 'laptop',
+        merchant_type: 'electronics',
       },
       null,
       2,


### PR DESCRIPTION
## Summary
- use model_type and signature inputs when calling `/v1/inference/predict`
- update Playground example payload and unit tests

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_689e2015fcd8832d921a97ccb050bde3