### PR TITLE
fix: correct docs request example

### DIFF
--- a/src/app/pages/docs/docs.component.html
+++ b/src/app/pages/docs/docs.component.html
@@ -26,9 +26,9 @@
         <p>
           To use the Fraud AI API, you must be authenticated. Authentication is handled via API keys. You can generate and manage your API keys from the <a routerLink="/keys">API Keys dashboard</a>.
         </p>
-        <p>
-          All API requests must include an <code>Authorization</code> header with your API key as a Bearer token.
-        </p>
+          <p>
+            All API requests must include an <code>x-api-key</code> header with your API key.
+          </p>
         <app-callout type="warn">
           <p><strong>Keep your API keys secure!</strong> Do not expose them in client-side code. All API requests should be made from a secure server-side environment.</p>
         </app-callout>
@@ -36,7 +36,7 @@
 
       <section id="api-reference">
         <h2>API Reference</h2>
-        <p>Our API has a single primary endpoint for fraud detection: <code>POST /v1/detect</code>. You send transaction or event data to this endpoint, and our models will return a risk score in real-time.</p>
+        <p>Our API has a single primary endpoint for fraud detection: <code>POST /v1/inference/predict</code>. You send transaction or event data to this endpoint, and our models will return a risk score in real-time.</p>
 
         <h3>Example Request</h3>
         <p>Below is an example of how to make a request to the detection endpoint using various languages. Select your preferred language to see the corresponding code snippet.</p>

--- a/src/app/pages/docs/docs.component.ts
+++ b/src/app/pages/docs/docs.component.ts
@@ -68,30 +68,33 @@ export class DocsPage implements OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-  generateSnippets(model: Model | null, apiKey: string | null) {
-    if (!model) {
-      return;
-    }
-    const endpoint = `${environment.apiBaseUrl}/v1/detect`;
-    const headers = {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey || 'YOUR_API_KEY'}`,
-    };
-    const body = {
-      model: model.id,
-      data: {
-        // Example data structure
-        amount: 120.50,
-        currency: 'USD',
-        user_id: 'user-12345',
-      },
-    };
+    generateSnippets(model: Model | null, apiKey: string | null) {
+      if (!model) {
+        return;
+      }
+      const endpoint = 'https://api.fraudai.cloud/v1/inference/predict';
+      const headers = {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey || 'YOUR_API_KEY',
+      };
+      const body = {
+        model: model.id,
+        features: {
+          transaction_id: 9876543210,
+          amount: 200.12,
+          merchant_type: 'electronics',
+          device_type: 'laptop',
+        },
+      };
 
-    const bodyString = JSON.stringify(body, null, 2);
+      const bodyString = JSON.stringify(body);
 
-    this.curlSnippet = `curl -X POST ${endpoint} \\\n-H "Content-Type: application/json" \\\n-H "Authorization: Bearer ${apiKey || 'YOUR_API_KEY'}" \\\n-d '${bodyString}'`;
+      this.curlSnippet = `curl -X POST '${endpoint}' \\
+  -H 'Content-Type: application/json' \\
+  -H 'x-api-key: ${apiKey || 'YOUR_API_KEY'}' \\
+  -d '${bodyString}'`;
 
-    this.fetchSnippet = `fetch('${endpoint}', {
+      this.fetchSnippet = `fetch('${endpoint}', {
   method: 'POST',
   headers: ${JSON.stringify(headers, null, 2)},
   body: JSON.stringify(${JSON.stringify(body, null, 2)})
@@ -99,14 +102,14 @@ export class DocsPage implements OnDestroy {
 .then(response => response.json())
 .then(data => console.log(data));`;
 
-    this.pythonSnippet = `import requests
+      this.pythonSnippet = `import requests
 import json
 
 url = "${endpoint}"
 headers = ${JSON.stringify(headers, null, 2)}
-data = ${bodyString}
+data = ${JSON.stringify(body, null, 2)}
 
 response = requests.post(url, headers=headers, data=json.dumps(data))
 print(response.json())`;
-  }
+    }
 }


### PR DESCRIPTION
## Summary
- update docs page to use x-api-key and new predict endpoint
- refresh curl/fetch/python examples with correct request body

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e25b5e86c832d9333102435d60523