### PR TITLE
fix broken docs section link

### DIFF
--- a/src/app/pages/docs/docs.component.html
+++ b/src/app/pages/docs/docs.component.html
@@ -61,6 +61,13 @@
           <p>Our error responses include a JSON body with a <code>code</code> and <code>message</code> field to help you debug.</p>
         </app-callout>
       </section>
+
+      <section id="sdk-libs">
+        <h2>SDKs &amp; Libraries</h2>
+        <p>
+          Official client libraries are currently under development. For now, you can interact with the API directly using the code examples above. Check back soon for updates on available SDKs.
+        </p>
+      </section>
     </article>
   </div>
 </ion-content>


### PR DESCRIPTION
## Summary
- add SDKs & Libraries section to docs to match sidebar links

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a083544468832dbef240a6c68c700a