### PR TITLE
docs: update API base URL

### DIFF
--- a/src/app/pages/docs/docs.component.html
+++ b/src/app/pages/docs/docs.component.html
@@ -36,6 +36,7 @@
 
       <section id="api-reference">
         <h2>API Reference</h2>
+        <p>The base URL for all API requests is <code>https://api.fraudai.cloud</code>.</p>
         <p>Our API has a single primary endpoint for fraud detection: <code>POST /v1/fraud/predict</code>. You send transaction or event data to this endpoint, and our models will return a risk score in real-time.</p>
 
         <h3>Example Request</h3>

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://api.fraud.ai', // Example production API URL
+  apiBaseUrl: 'https://api.fraudai.cloud', // Example production API URL
   useMock: false,
 };


### PR DESCRIPTION
## Summary
- document base API URL in docs page
- point production environment to https://api.fraudai.cloud
- replace legacy api.fraud.ai references

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*

------
https://chatgpt.com/codex/tasks/task_e_68a08358e618832dace69b995a1d3baf