### PR TITLE
feat: handle empty docs snippets and stabilize code highlighting

### DIFF
--- a/src/app/pages/docs/docs.component.ts
+++ b/src/app/pages/docs/docs.component.ts
@@ -70,6 +70,10 @@ export class DocsPage implements OnDestroy {
 
     generateSnippets(model: Model | null, apiKey: string | null) {
       if (!model) {
+        const placeholder = 'Select a model to generate code snippet.';
+        this.curlSnippet = placeholder;
+        this.fetchSnippet = placeholder;
+        this.pythonSnippet = placeholder;
         return;
       }
       const endpoint = 'https://api.fraudai.cloud/v1/inference/predict';

--- a/src/app/shared/components/code-block/code-block.component.ts
+++ b/src/app/shared/components/code-block/code-block.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, AfterViewInit, OnChanges, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, AfterViewInit, OnChanges, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CopyButtonComponent } from '../copy-button/copy-button.component';
 import hljs from 'highlight.js/lib/core';
@@ -17,24 +17,32 @@ hljs.registerLanguage('python', python);
   standalone: true,
   imports: [CommonModule, CopyButtonComponent],
 })
-export class CodeBlockComponent implements AfterViewInit, OnChanges {
+export class CodeBlockComponent implements AfterViewInit, OnChanges, AfterViewChecked {
   @Input() code = '';
   @Input() language = 'typescript';
   @ViewChild('codeElement') codeElement?: ElementRef<HTMLElement>;
 
+  private needsHighlight = false;
+
   ngAfterViewInit() {
-    this.highlight();
+    this.needsHighlight = true;
   }
 
   ngOnChanges() {
-    this.highlight();
+    this.needsHighlight = true;
+  }
+
+  ngAfterViewChecked() {
+    if (this.needsHighlight) {
+      this.highlight();
+      this.needsHighlight = false;
+    }
   }
 
   private highlight() {
-    setTimeout(() => {
-      if (this.codeElement) {
-        hljs.highlightElement(this.codeElement.nativeElement);
-      }
-    });
+    if (this.codeElement) {
+      this.codeElement.nativeElement.textContent = this.code;
+      hljs.highlightElement(this.codeElement.nativeElement);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- show placeholder snippets when no model is selected in docs
- ensure code block highlight.js runs after text updates for consistent rendering

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68a0835af934832d91ea2933305b6b7b