### PR TITLE
Fix docs sidebar navigation

### DIFF
--- a/src/app/pages/docs/docs.component.html
+++ b/src/app/pages/docs/docs.component.html
@@ -1,13 +1,13 @@
 <ion-content [fullscreen]="true">
   <div class="docs-container app-container">
     <!-- Sidebar -->
-    <nav class="docs-sidebar">
-      <ul class="sidebar-nav-list">
-        <li *ngFor="let section of sections">
-          <a [href]="'#' + section.id" class="sidebar-link">{{ section.title }}</a>
-        </li>
-      </ul>
-    </nav>
+      <nav class="docs-sidebar">
+        <ul class="sidebar-nav-list">
+          <li *ngFor="let section of sections">
+            <a class="sidebar-link" (click)="scrollToSection(section.id)">{{ section.title }}</a>
+          </li>
+        </ul>
+      </nav>
 
     <!-- Main Content -->
     <article class="docs-content">

--- a/src/app/pages/docs/docs.component.ts
+++ b/src/app/pages/docs/docs.component.ts
@@ -69,11 +69,18 @@ export class DocsPage implements OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-    generateSnippets(apiKey: string | null) {
-      const model = this.exampleModel;
-      const endpoint = 'https://api.fraudai.cloud/v1/inference/predict';
-      const headers = {
-        'Content-Type': 'application/json',
+  scrollToSection(id: string) {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth' });
+    }
+  }
+
+  generateSnippets(apiKey: string | null) {
+    const model = this.exampleModel;
+    const endpoint = 'https://api.fraudai.cloud/v1/inference/predict';
+    const headers = {
+      'Content-Type': 'application/json',
         'x-api-key': apiKey || 'YOUR_API_KEY',
       };
       const body = {


### PR DESCRIPTION
## Summary
- avoid router redirect by handling sidebar link clicks manually
- add scroll-to-section helper to docs page

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a09aeed300832db519f3cde06dfe59