### PR TITLE
feat: Add SVG favicon for Onyx Neon theme

### DIFF
--- a/src/assets/icon/favicon.svg
+++ b/src/assets/icon/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="glow">
+      <feDropShadow dx="0" dy="0" stdDeviation="3" flood-color="hsl(170 85% 40%)" />
+    </filter>
+  </defs>
+  <circle cx="16" cy="16" r="12" fill="hsl(170 85% 40%)" filter="url(#glow)" />
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@
   <meta name="format-detection" content="telephone=no" />
   <meta name="msapplication-tap-highlight" content="no" />
 
-  <link rel="icon" type="image/png" href="assets/icon/favicon.png" />
+  <link rel="icon" type="image/svg+xml" href="assets/icon/favicon.svg" />
 
   <!-- add to homescreen for ios -->
   <meta name="mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
This commit introduces a new SVG-based favicon to align with the website's "Onyx Neon" design system.

- A new file, `favicon.svg`, has been created in `src/assets/icon/`. The icon is a simple glowing teal orb that matches the theme's primary color.
- The `src/index.html` file has been updated to link to the new SVG favicon, changing the `type` attribute to `image/svg+xml`.
- The old `favicon.png` is not removed, but is no longer referenced.