### PR TITLE
feat: delay guard until auth initialized

### DIFF
--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,14 +1,17 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { AuthService } from '../services/auth.service';
-import { map, take } from 'rxjs/operators';
+import { map, take, filter, switchMap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 export const authGuard: CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> => {
   const authService = inject(AuthService);
   const router = inject(Router);
 
-  return authService.user$.pipe(
+  return authService.initialized$.pipe(
+    filter(Boolean),
+    take(1),
+    switchMap(() => authService.user$),
     take(1),
     map(user => {
       const isAuthenticated = !!user;


### PR DESCRIPTION
## Summary
- track initialization state in `AuthService`
- wait for `AuthService` init before evaluating auth guard
- test guard behavior with initialized user

## Testing
- `CHROME_BIN=/tmp/chrome.sh npm test -- --watch=false --browsers=ChromeHeadless --include src/app/core/guards/auth.guard.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a1a0b6f444832d8fc3d6e4b98d4dad